### PR TITLE
refactor: improve change category parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.2.0] - 2025-06-17
+
+### Enhanced
+- Made change category detection more flexible: the parser now supports a mix of categorized and uncategorized entries within the same changelog.
+- Set default entry type to `"N/D"` when no change category is matched, enabling smoother fallback behavior.
+
+### Deprecated
+- The `"change-type"` config field is now ignored. It is still accepted in config files for backward compatibility but no longer affects parsing behavior.
+
 ## [2.1.0] - 2025-05-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ For an example of practical configuration go [here](.\config\changelog-config.js
         "regex-patterns": { // Patterns used to parse the changelog
             "version-line": "^## \\d+\\.\\d+\\.\\d+ \\([A-Za-z]+ \\d{1,2}, \\d{4}\\)", // Regex to identify version lines
             "version": "(\\d+\\.\\d+\\.\\d+)", // Regex to extract version numbers
-            "change-type": true, // Indicates whether the changelog includes explicit "change type" sections (e.g., "### Added", "### Fixed"). Set to true if such sections are present; otherwise, set to false to treat all entries as uncategorized.
             "change-categories": [ // Definitions for different change categories
                 {
                     "name": "__default", // Default category if no specific match

--- a/config/changelog-config.json
+++ b/config/changelog-config.json
@@ -4,7 +4,6 @@
         "regex-patterns": {
             "version-line": "^## \\d+\\.\\d+\\.\\d+ \\([A-Za-z]+ \\d{1,2}, \\d{4}\\)",
             "version": "(\\d+\\.\\d+\\.\\d+)",
-            "change-type": true,
             "change-categories": [
                 {
                     "name": "__default",
@@ -87,7 +86,6 @@
         "regex-patterns": {
             "version-line": "^## \\d+\\.\\d+\\.\\d+ \\([A-Za-z]+ \\d{1,2}, \\d{4}\\)",
             "version": "(\\d+\\.\\d+\\.\\d+)",
-            "change-type": true,
             "change-categories": [
                 {
                     "name": "__default",
@@ -181,7 +179,6 @@
         "regex-patterns": {
             "version-line": "^## \\[\\d+\\.\\d+\\.\\d+\\]\\(https:\/\/github\\.com\/.+?\\) - \\d{4}-\\d{2}-\\d{2}$",
             "version": "(\\d+\\.\\d+\\.\\d+)",
-            "change-type": true,
             "change-categories": [
                 {
                     "name": "__default",
@@ -234,7 +231,6 @@
         "regex-patterns": {
             "version-line": "^## \\d+\\.\\d+\\.\\d+ \\(\\d{4}-\\d{2}-\\d{2}\\)",
             "version": "(\\d+\\.\\d+\\.\\d+)",
-            "change-type": true,
             "change-categories": [
                 {
                     "name": "__default",
@@ -315,7 +311,6 @@
         "regex-patterns": {
             "version-line": "^## \\[[0-9]*.[0-9]*.[0-9]*.[0-9]*\\]",
             "version": "(?<=## \\[)(\\d+\\.\\d+\\.\\d+)(?=\\])",
-            "change-type": false,
             "change-categories": [
                 {
                     "name": "__default",


### PR DESCRIPTION
### What
Refactored the parsing logic to support changelogs that contain a mix of categorized and uncategorized entries.

### Why
Previously, the parser required either all entries to be categorized or none. This change allows more flexible changelog formats, where some entries have an explicit change type and others don't.

### Additional Notes
- The `change-type` field in the configuration is now ignored. It has been deprecated but is still accepted to maintain backward compatibility.
- This change does not introduce any breaking changes for existing configs.

### Related
Branch: `refactor/change-category-logic`
