### PR TITLE
feat: add support for terraform-provider-azuread changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.3.0] - 2025-06-17
+
+### Added
+- Support for `terraform-provider-azuread` changelogs in `changelog-config.json`.
+- 
 ## [2.2.1] - 2025-06-17
 
 ### Refactored

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 | -------- | ----------------- | ---------- | ----------------- |
 | **azurerm-v3** | 3.x | [terraform-provider-azurerm](https://github.com/hashicorp/terraform-provider-azurerm) | [AzureRM v3 Changelog](https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/refs/heads/main/CHANGELOG-v3.md) |
 | **azurerm-v4** | 4.x | [terraform-provider-azurerm](https://github.com/hashicorp/terraform-provider-azurerm) | [AzureRM v4 Changelog](https://raw.githubusercontent.com/hashicorp/terraform-provider-azurerm/refs/heads/main/CHANGELOG.md) |
+| **azuread** | All | [terraform-provider-azuread](https://github.com/hashicorp/terraform-provider-azuread) | [AzureAD Changelog](https://raw.githubusercontent.com/hashicorp/terraform-provider-azuread/refs/heads/main/CHANGELOG.md) |
 | **checkov** | All | [checkov](https://github.com/bridgecrewio/checkov/) | [Checkov Changelog](https://raw.githubusercontent.com/bridgecrewio/checkov/refs/heads/main/CHANGELOG.md) |
 | **gitlab-v17** | 17.x | [GitLab](https://gitlab.com/gitlab-org/gitlab/) | [GitLab Changelog](https://gitlab.com/gitlab-org/gitlab/-/raw/master/CHANGELOG.md) |
 | **helm-chart-sonarqube** | All | [helm-chart-sonarqube](https://github.com/SonarSource/helm-chart-sonarqube) | [helm-chart-sonarqube Changelog](https://github.com/SonarSource/helm-chart-sonarqube/blob/master/charts/sonarqube/CHANGELOG.md) |

--- a/config/changelog-config.json
+++ b/config/changelog-config.json
@@ -329,5 +329,134 @@
                 "- no noteworthy changes"
             ]
         }
+    },
+    "terraform-provider-azuread": {
+        "changelog-url": "https://raw.githubusercontent.com/hashicorp/terraform-provider-azuread/refs/heads/main/CHANGELOG.md",
+        "regex-patterns": {
+            "version-line": "^## \\d+\\.\\d+\\.\\d+ \\([A-Za-z]{3,9} \\d{1,2}, \\d{4}\\)",
+            "version": "\\d+\\.\\d+\\.\\d+",
+            "change-categories": [
+                {
+                    "name": "__default",
+                    "patterns": {
+                        "match": {
+                            "name": "(?<=`)[^`]+(?=`)",
+                            "description": "(?<=- ).*"
+                        }
+                    }
+                },
+                {
+                    "name": "N/D",
+                    "name-pattern": "__nd",
+                    "default-pattern": false,
+                    "patterns": {
+                        "match": {
+                            "name": "(?<=`)[^`]+(?=`)",
+                            "description": "^\\* .*"
+                        },
+                        "replace": {
+                            "description": "^\\* "
+                        }
+                    }
+                },
+                {
+                    "name": "FEATURES",
+                    "name-pattern": "^FEATURES$",
+                    "default-pattern": false,
+                    "patterns": {
+                        "match": {
+                            "name": "^\\*\\s*\\*{0,2}(.+?):\\*{0,2}",
+                            "description": "^\\* .*"
+                        },
+                        "replace": {
+                            "name": "[*:]",
+                            "description": "^\\*\\s*(.*?): "
+                        }
+                    }
+                },
+                {
+                    "name": "ENHANCEMENTS",
+                    "name-pattern": "^ENHANCEMENTS$",
+                    "default-pattern": false,
+                    "patterns": {
+                        "match": {
+                            "name": "(?<=`)[^`]+(?=`)",
+                            "description": "^\\* .*"
+                        },
+                        "replace": {
+                            "description": "^\\* "
+                        }
+                    }
+                },
+                {
+                    "name": "BUG FIXES",
+                    "name-pattern": "^BUG FIXES$",
+                    "default-pattern": false,
+                    "patterns": {
+                        "match": {
+                            "name": "(?<=`)[^`]+(?=`)",
+                            "description": "^\\* .*"
+                        },
+                        "replace": {
+                            "description": "^\\* "
+                        }
+                    }
+                },
+                {
+                    "name": "IMPROVEMENTS",
+                    "name-pattern": "^IMPROVEMENTS$",
+                    "default-pattern": false,
+                    "patterns": {
+                        "match": {
+                            "name": "(?<=`)[^`]+(?=`)",
+                            "description": "^\\* .*"
+                        },
+                        "replace": {
+                            "description": "^\\* "
+                        }
+                    }
+                },
+                {
+                    "name": "NOTES",
+                    "name-pattern": "^NOTES$",
+                    "patterns": {
+                        "match": {
+                            "description": "^\\* .*"
+                        },
+                        "replace": {
+                            "description": "^\\* "
+                        }
+                    }
+                },
+                {
+                    "name": "BREAKING CHANGES",
+                    "name-pattern": "^BREAKING CHANGES$",
+                    "default-pattern": false,
+                    "patterns": {
+                        "match": {
+                            "name": "(?<=`)[^`]+(?=`)",
+                            "description": "^\\* .*"
+                        },
+                        "replace": {
+                            "description": "^\\* "
+                        }
+                    }
+                },
+                {
+                    "name": "DEPRECATIONS",
+                    "name-pattern": "^DEPRECATIONS$",
+                    "default-pattern": true
+                },
+                {
+                    "name": "DEVELOPER NOTE",
+                    "name-pattern": "^DEVELOPER NOTE$",
+                    "default-pattern": true
+                }
+            ],
+            "specials": [],
+            "ignore": [
+                "Initial release of the Azure Active Directory provider - featuring resources split out from the AzureRM Provider."
+            ]
+        }
     }
 }


### PR DESCRIPTION
### What
Adds support for parsing the changelog format used by [terraform-provider-azuread](https://github.com/hashicorp/terraform-provider-azuread).

### Changes
- Added configuration for `terraform-provider-azuread` in `changelog-config.json`.

### Why
This enables Log2Csv to extract structured changelog data from that project, expanding compatibility with widely used Terraform providers.